### PR TITLE
Wywalenie exit 1

### DIFF
--- a/zabojcaspamu_downlad_blacklist.sh
+++ b/zabojcaspamu_downlad_blacklist.sh
@@ -28,6 +28,7 @@ for FILE in ${FILE_BL[*]};do
     RETV=$?
         if [ "$RETV" -ne "0" ];then
         echo "$SIGN_DATA Plik $FILE sciagniety ale suma kontrola sie nie zgadza"  >> ${LOG_FILE}
+        else
         cp -f ${WORK_DIR}/${FILE} ${SAVE_DIR}/${FILE} 2>/dev/null
         RETV=$?
             if [ "$RETV" -ne "0" ];then

--- a/zabojcaspamu_downlad_blacklist.sh
+++ b/zabojcaspamu_downlad_blacklist.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # Wgrywanie blacklist ze strony http://zabojcaspamu.pl
-# 
-# v0.2 2018-07-02 Start script
+#
+# v0.3 2019-03-17 Start script
 # https://zabojcaspamu.pl/program-sciagania-blacklist/
 
-# Katalog tymaczasowy do policzenia sumy kontrolnej 
+# Katalog tymaczasowy do policzenia sumy kontrolnej
 WORK_DIR="/tmp"
 # Katalog docelowy z ktorego zaczytuje reguly SA
 SAVE_DIR="/etc/spamassassin"
@@ -21,24 +21,20 @@ for FILE in ${FILE_BL[*]};do
     curl -sL https://zabojcaspamu.pl/$FILE -o ${WORK_DIR}/${FILE}
     RETV=$?
     if [ "$RETV" -ne "0" ];then
-       echo "$SIGN_DATA Blad podczas sciagania pliku" >> ${LOG_FILE}
-       exit 1
-    fi
+        echo "$SIGN_DATA Blad podczas sciagania pliku" >> ${LOG_FILE}
+    else
     SUMA=`curl -s https://zabojcaspamu.pl/md5sum.txt|grep  $FILE|awk '{print $1}'`
     echo "$SUMA ${WORK_DIR}/${FILE}" | md5sum -c - >/dev/null
     RETV=$?
-    if [ "$RETV" -ne "0" ];then
-       echo "$SIGN_DATA Plik $FILE sciagniety ale suma kontrola sie nie zgadza"  >> ${LOG_FILE}
-       exit 1
+        if [ "$RETV" -ne "0" ];then
+        echo "$SIGN_DATA Plik $FILE sciagniety ale suma kontrola sie nie zgadza"  >> ${LOG_FILE}
+        cp -f ${WORK_DIR}/${FILE} ${SAVE_DIR}/${FILE} 2>/dev/null
+        RETV=$?
+            if [ "$RETV" -ne "0" ];then
+            echo "$SIGN_DATA Plik $FILE sciagniety suma kontrola OK ale przegranie do $SAVE_DIR katalogu sie nie powiodlo"  >> ${LOG_FILE}
+            else
+            echo "$SIGN_DATA  Plik $FILE sciagniety i wgrany prawidlowo do $SAVE_DIR"  >> ${LOG_FILE}
+            fi
+        fi
     fi
-
-    cp -f ${WORK_DIR}/${FILE} ${SAVE_DIR}/${FILE} 2>/dev/null
-    RETV=$?
-    if [ "$RETV" -ne "0" ];then
-       echo "$SIGN_DATA Plik $FILE sciagniety suma kontrola OK ale przegranie do $SAVE_DIR katalogu sie nie powiodlo"  >> ${LOG_FILE}
-       exit 1
-    fi
-
-    echo "$SIGN_DATA  Plik $FILE sciagniety i wgrany prawidlowo do $SAVE_DIR"  >> ${LOG_FILE}
 done
-


### PR DESCRIPTION
Wywalenie wszystkich exit 1 aby wszystkie pliki były ściągane, ponieważ do tej pory jeśli był problem z jakimkolwiek plikiem skrypt kończył swoje działanie. Teraz próbuje każdy plik ściągnąć, sprawdzić sumę md5 a następnie przegrać do katalogu i jakikolwiek błąd nie powoduje zatrzymanie skryptu.