### PR TITLE
Poprawiona reguła ZABOJCASPAMU_SPF_REQ_2

### DIFF
--- a/local.cf.reguly.ZABOJCASPAMU
+++ b/local.cf.reguly.ZABOJCASPAMU
@@ -822,7 +822,7 @@ describe ZABOJCASPAMU_TWO_REDDCC ( DCC_CHECK && ZABOJCASPAMU_RED_COLOR)
 score    ZABOJCASPAMU_TWO_REDDCC 2
 
 header    __ZABOJCASPAMU_SPF_REQ_2_1  From:addr=~/(dhl\.com|dhl\.pl|poczta\-polska\.pl|inpost\.pl|paczkomaty\.pl)/
-header    __ZABOJCASPAMU_SPF_REQ_2_2   ALL=~/(spf|SPF)(=|:) *pass.+\@(dhl\.com|dhl\.pl|poczta\-polska\.pl|inpost\.pl|paczkomaty\.pl)/
+header    __ZABOJCASPAMU_SPF_REQ_2_2   ALL=~/(spf|SPF)(=|:) *pass.+(\@|mailfrom=)(dhl\.com|dhl\.pl|poczta\-polska\.pl|inpost\.pl|paczkomaty\.pl)/
 meta      ZABOJCASPAMU_SPF_REQ_2    __ZABOJCASPAMU_SPF_REQ_2_1 && ! __ZABOJCASPAMU_SPF_REQ_2_2
 describe  ZABOJCASPAMU_SPF_REQ_2 Wymagane SPF dla domen
 score     ZABOJCASPAMU_SPF_REQ_2 5


### PR DESCRIPTION
poprawka dla ```Authentication-Results: host; spf=pass smtp.mailfrom=paczkomaty.pl```